### PR TITLE
Be specific about python version.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ Code conventions
 Before contributing a change please activate pre-commit checks locally:
 
 ```bash
-
 $ pip3 install pre-commit
 $ pre-commit install
 ```

--- a/anod
+++ b/anod
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Simple front-end to the task-specific anod scripts contained in lib."""
 

--- a/install/install
+++ b/install/install
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 """
 Install front-end script.

--- a/install/install-anod-venv
+++ b/install/install-anod-venv
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 """
 Install anod virtual environment script.

--- a/install/install-gnat
+++ b/install/install-gnat
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 """
 Install GNAT script.

--- a/lib/anod_build.py
+++ b/lib/anod_build.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+"""Anod-based build script."""
 
 from __future__ import annotations
 
@@ -27,6 +29,7 @@ BUILD_SUCCESS = [
 
 
 def do_build(m: Main, set_prog: bool = True) -> int:
+    """Perform the build."""
     if set_prog:
         m.argument_parser.prog = m.argument_parser.prog + " build"
     m.argument_parser.add_argument(

--- a/lib/anod_devel_setup.py
+++ b/lib/anod_devel_setup.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 """Script to configure OpenUxAS anod environment for development work."""
 
@@ -47,7 +47,7 @@ anod so that the checked out repositories will be used during the build.
 
 For example, run:
 
-  ./anod-devel-setup --uxas
+  ./anod devel-setup uxas
 
 to check out OpenUxAS for development. By default, the checkout will be in
 `develop/OpenUxAS`.
@@ -69,6 +69,7 @@ current state for the build.
 
 
 def update_yaml(yaml_filename: str, key: str, clone_dir: str) -> None:
+    """Update the given yaml file for the specified component."""
     with open(yaml_filename, "r") as yaml_file:
         loaded_yaml = yaml.safe_load(yaml_file.read())
 
@@ -81,6 +82,12 @@ def update_yaml(yaml_filename: str, key: str, clone_dir: str) -> None:
 
 
 def check_out(name: str, remote: str, refspec: str, clone_dir: str) -> None:
+    """
+    Check out the given repository.
+
+    This is a deep (non-shallow) checkout, which differs from e3's typical
+    operation.
+    """
     if not os.path.exists(clone_dir):
         logging.info(
             "Checking out %s\n        from %s %s\n        to %s"
@@ -99,6 +106,7 @@ def configure_argparse_for_component(
     default_remote: str,
     default_refspec: str,
 ) -> None:
+    """Add arguments to argparse for the given component."""
     ap.add_argument(
         "--%s-clone-dir" % key,
         default=default_dir,
@@ -120,6 +128,7 @@ def configure_argparse_for_component(
 
 
 def do_devel_setup(m: Main, set_prog: bool = True) -> int:
+    """Execute the main functionality of the script."""
     if set_prog:
         m.argument_parser.prog = m.argument_parser.prog + " devel-setup"
 

--- a/lib/anod_printenv.py
+++ b/lib/anod_printenv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Anod environment printer."""
 

--- a/specs/amase.anod
+++ b/specs/amase.anod
@@ -4,7 +4,7 @@ from e3.fs import sync_tree, cp, mkdir
 from e3.os.fs import chmod
 import os
 
-AMASE_LAUNCHER_SCRIPT = """#!/usr/bin/env python
+AMASE_LAUNCHER_SCRIPT = """#!/usr/bin/env python3
 
 import subprocess
 import os


### PR DESCRIPTION
Make sure references to python in shebangs and in text specify python3
rather than simply python. This better supports convention of fresh
machines.