### PR TITLE
Fix for issue #8

### DIFF
--- a/install/bootstrap
+++ b/install/bootstrap
@@ -105,7 +105,9 @@ failed_checkout() {
 }
 
 checkout() {
-  (git fetch --unshallow --update-head-ok origin '+refs/heads/*:refs/heads/*' \
+  (git fetch --unshallow \
+     && git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" \
+     && git fetch \
      && git checkout "$1") || failed_checkout "$1"
 }
 


### PR DESCRIPTION
Correct the approach to unshallow the original clone.

The easiest way to test this is to grab just the boostrap file out of this PR, and run it like this:

```
cat bootstrap | BOOTSTRAP_ROOT=~/daidalus BOOTSTRAP_REF=daidalus_integration bash
```

Then, cd to ~/daidalus and run:

```
git remote show origin
```

Verify that the daidalus_integration branch is listed as tracked.